### PR TITLE
all applied migrations on initial migration are new

### DIFF
--- a/lib/command/apply.ts
+++ b/lib/command/apply.ts
@@ -54,7 +54,7 @@ export default function apply(config: Config) {
 
   let previousEntry = journal.then(es => R.last(es));
   let newEntries = Promise.join(previousEntry, apply, (prev, es) =>
-    R.filter(e => e.timestamp > prev.timestamp, es)
+    prev ? R.filter(e => e.timestamp > prev.timestamp, es) : apply
   );
 
   return newEntries


### PR DESCRIPTION
on the initial run, there are no previous entries. this pr sets
newEntries to match all applied entries in this case, which
fixes gh-2
